### PR TITLE
Item.from_page_object

### DIFF
--- a/zyte_common_items/util.py
+++ b/zyte_common_items/util.py
@@ -1,3 +1,4 @@
+import inspect
 from typing import Any, Callable, Dict, Optional, Tuple, Type
 from weakref import WeakKeyDictionary
 
@@ -53,3 +54,10 @@ def get_origin(tp) -> Tuple:
     typing.get_origin(tp) is only available startingo on 3.8.
     """
     return getattr(tp, "__origin__", ())
+
+
+async def maybe_await(obj):
+    """Return the value of obj, awaiting it if needed"""
+    if inspect.isawaitable(obj):
+        return await obj
+    return obj


### PR DESCRIPTION
This is an alternative to https://github.com/scrapinghub/web-poet/pull/53.

It allows to implement page objects this way:

```py
@attrs.define
class MyProductPage(ItemPage):
    response: HttpResponse

    def url(self) -> str:
        return self.response.url

    def price(self) -> str:
        return self.response.css(".price").get()

    async def currency(self) -> str:
        return "$"

    async def to_item(self) -> Product:
        item = await Product.from_page_object(self)
        # further processing, if needed
        return item
```

With a mixin (not implemented), it could look like this:

```py
@attrs.define
class MyProductPage(ItemPage, AutoMixin[Product]):
    response: HttpResponse

    def url(self) -> str:
        return self.response.url

    def price(self) -> str:
        return self.response.css(".price").get()

    async def currency(self) -> str:
        return "$"
```