### PR TITLE
create use_converter_shortcuts() as a field_transformer

### DIFF
--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -11,6 +11,7 @@ from web_poet import HttpResponse, RequestUrl, ResponseUrl
 from zyte_common_items import (
     Breadcrumb,
     Image,
+    Item,
     Link,
     Product,
     ProductFromList,
@@ -146,7 +147,7 @@ def test_webpoet_URL_images(cls):
 
 def test_use_converter_shortcuts():
     @attrs.define(field_transformer=use_converter_shortcuts)
-    class Data:
+    class Data(Item):
         x: Optional[str] = attrs.field(converter=lambda x: x.strip())
         y: Optional[str] = None
         z: Optional[str] = None
@@ -171,3 +172,21 @@ def test_use_converter_shortcuts():
 
     d.z = "  value "
     assert d.z == "value"
+
+    d = Data.from_dict({"x": " x ", "y": " y ", "z": " z "})
+    assert d.x == "x"
+    assert d.y == "y"
+    assert d.z == "z"
+
+    d = Data.from_list(
+        [
+            {"x": " x1 ", "y": " y1 ", "z": " z1 "},
+            {"x": " x2 ", "y": " y2 ", "z": " z2 "},
+        ]
+    )
+    assert d[0].x == "x1"
+    assert d[0].y == "y1"
+    assert d[0].z == "z1"
+    assert d[1].x == "x2"
+    assert d[1].y == "y2"
+    assert d[1].z == "z2"

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ deps =
     pytest
     pytest-cov
     pytest-mypy-testing==0.0.11
+    itemloaders
     # Needed for the `py.typed` addition since 'web-poet<=0.4.0' didn't have it.
     # This can be removed when 'web-poet' is bumped to '>=0.5.0' in `setup.py`.
     git+https://git@github.com/scrapinghub/web-poet@facd6d0#egg=web-poet


### PR DESCRIPTION
# Motivation

Scrapy developers find it natural to use the preprocessor syntax of itemloaders: https://itemloaders.readthedocs.io/en/latest/declaring-loaders.html.

Itemloaders use such **Input** and **Output processors** to preprocess the data when each field is added using `add_value()`, `add_xpath()` and `add_css()` as well as producing an item via `load_item()`. The **zyte-common-items** on the other hand are already the items that we need. So we don't need to call `load_item()` to it, losing the need for an **Output processor** like `<field>_out.`

However, it still needs the **Input processor** like `<field>_in` to preprocess/sanitize values being assigned to the item via field assignments, `from_dict()`, and `from_list()`.

Since items are already attrs classes, we have the converter functionality available to us. This would look like:
```python
@attrs.define
class SomeItem(Item):
    pageNumber: Optional[int] = attrs.field(default=None, converter=process_pagenum)
```

We could retain the `<field>_in` as a shortcut to the converter like:

```python
def process_pagenum(value):
    ...

@attrs.define
class SomeItem(Item):
    pageNumber: Optional[int] = None
    pageNumber_in = process_pagenum
```

# Proposal

Create a new **field_transformer** to be used with **attrs** called `use_converter_shortcuts`. Here's an example:

```python
from typing import Optional
from zyte_common_items.utils import use_converter_shortcuts
import attrs


@attrs.define(field_transformer=use_converter_shortcuts)
class Data:
    x: Optional[str] = attrs.field(converter=lambda x: x.strip())
    y: Optional[str] = None
    z: Optional[str] = None

    y_in = lambda y: y.strip()

    @staticmethod
    def z_in(z):
        return z.strip()

print(Data(x=" text ", y=" hi ", z=" asd \n"))  # Data(x='text', y='hi', z='asd')

d.x = " $32.88\n "
print(d.x)  # "$32.88"

d.y = " hello "
print(d.y)  # "hello"

d.z = "  value "
print(d.z)  # "value"   
```

The field `x` follows the usual route of declaring converters in **attrs** to preprocess the data.

The fields `y` and `z` closely follow the method of how Scrapy's itemloaders declare the preprocessors for each field.

# To Discuss

1. Should we use another suffix aside from `*_in`?
2. Should we rename `use_converter_shortcuts` to something else?
3. Should the use of `use_converter_shortcuts` be opt-in? _(like what we've done currently)_ or should it be enabled for all subclasses of `zyte_common_items.Item`?
4. What's the expected behavior when there's already a converter already defined? For example, 
does `x_in` override the lambda converter in the example below or not?

```python
@attrs.define(field_transformer=use_converter_shortcuts)
class Data:
    x: Optional[str] = attrs.field(converter=lambda x: x.strip())
    x_in = lambda x: x.strip() + "substring"
```


# TODO:
- docs
    - [ ] tutorial
- more tests
    - [ ] check if it works in parent class fields
    - [ ] slots
    - [ ] frozenclass