### PR TITLE
Remove metadata field from base

### DIFF
--- a/zyte_common_items/pages.py
+++ b/zyte_common_items/pages.py
@@ -8,8 +8,7 @@ from .items import Product, ProductList
 
 
 class _BaseMixin:
-    @field
-    def metadata(self) -> Metadata:
+    def _metadata(self) -> Metadata:
         return Metadata(
             dateDownloaded=f"{datetime.utcnow().isoformat(timespec='seconds')}Z",
             probability=1.0,
@@ -23,6 +22,10 @@ class BasePage(_BaseMixin, ItemPage):
     @field
     def url(self) -> str:
         return str(self.request_url)
+
+    @field
+    def metadata(self) -> Metadata:
+        return self._metadata()
 
 
 class BaseProductPage(BasePage, Returns[Product]):
@@ -38,6 +41,10 @@ class Page(_BaseMixin, WebPage):
     @field
     def url(self) -> str:
         return str(self.response.url)
+
+    @field
+    def metadata(self) -> Metadata:
+        return self._metadata()
 
 
 class ProductPage(Page, Returns[Product]):


### PR DESCRIPTION
Following sample pair of page objects were used:
```python
import attrs
from web_poet import field, handle_urls
from zyte_common_items import ProductListPage, ProductPage


@handle_urls("toscrape.com", instead_of=ProductListPage)
@attrs.define
class ToScrapeListingPage(ProductListPage):
    @field
    def products(self):
        return [{"name": "test"}, {"name": "drive"}]


@handle_urls("toscrape.com", instead_of=ProductPage)
@attrs.define
class ToScrapeProductPage(ProductPage):
    @field
    def brand(self):
        return {"name": "Test drive"}
```
For some reason having this `metadata` field in common base caused both types of Page Objects to share single instance of internal `_web_poet_fields_info` data. Moving field out of  `_BaseMixin` somehow fixes this. Posted as a quick-fix so we can proceed.
