### PR TITLE
Fix BaseMixin field leak

### DIFF
--- a/tests/test_pages.py
+++ b/tests/test_pages.py
@@ -101,3 +101,23 @@ async def test_example():
     item_datetime = datetime.fromisoformat(item_datetime_string[:-1])
     datetime_after = datetime.utcnow().replace(microsecond=0)
     assert datetime_before <= item_datetime <= datetime_after
+
+
+@pytest.mark.asyncio
+async def test_mixin_leak():
+    """https://github.com/zytedata/zyte-common-items/pull/29"""
+
+    class MyProductListPage(ProductListPage):
+        @field
+        def products(self):
+            return [{"name": "foo"}, {"name": "bar"}]
+
+    class MyProductPage(ProductPage):
+        @field
+        def brand(self):
+            return "baz"
+
+    from web_poet.fields import get_fields_dict
+
+    assert set(get_fields_dict(MyProductListPage)) == {"metadata", "products", "url"}
+    assert set(get_fields_dict(MyProductPage)) == {"brand", "metadata", "url"}

--- a/zyte_common_items/pages.py
+++ b/zyte_common_items/pages.py
@@ -2,12 +2,13 @@ from datetime import datetime
 
 import attrs
 from web_poet import ItemPage, RequestUrl, Returns, WebPage, field
+from web_poet.fields import FieldsMixin
 
 from .components import Metadata
 from .items import Product, ProductList
 
 
-class _BaseMixin:
+class _BaseMixin(FieldsMixin):
     @field
     def metadata(self) -> Metadata:
         return Metadata(


### PR DESCRIPTION
Closes #29.

https://github.com/scrapinghub/web-poet/pull/153 is related, but does not actually affect zyte-common-items since when we inherit from `_BaseMixin` it is the first base class and the rest (ItemPage, WebPage) do not define fields of their own.