### PR TITLE
Improve bad input reporting

### DIFF
--- a/docs/usage/items.rst
+++ b/docs/usage/items.rst
@@ -116,7 +116,7 @@ input:
 >>> product = Product.from_dict(data)
 Traceback (most recent call last):
 ...
-ValueError: Expected 'mainImage' to be a dict with fields from zyte_common_items.components.Image, got 'not a dictionary'.
+ValueError: Expected mainImage to be a dict with fields from zyte_common_items.components.Image, got 'not a dictionary'.
 >>> data = {
 ...     'url': 'https://example.com/',
 ...     'breadcrumbs': 3,
@@ -124,7 +124,7 @@ ValueError: Expected 'mainImage' to be a dict with fields from zyte_common_items
 >>> product = Product.from_dict(data)
 Traceback (most recent call last):
 ...
-ValueError: Expected 'breadcrumbs' to be a list of dicts with fields from zyte_common_items.components.Breadcrumb, got 3.
+ValueError: Expected breadcrumbs to be a list, got 3.
 
 
 Defining custom items

--- a/zyte_common_items/base.py
+++ b/zyte_common_items/base.py
@@ -20,6 +20,8 @@ import attrs
 
 from .util import split_in_unknown_and_known_fields
 
+Breadcrumbs = Optional[str]
+
 
 def is_data_container(cls_or_obj):
     """Used for discerning classes/instances if they are part of the Zyte Common
@@ -38,30 +40,66 @@ class _ItemBase:
     __slots__ = ("_unknown_fields_dict",)
 
 
+def _get_import_path(obj: type):
+    return f"{obj.__module__}.{obj.__qualname__}"
+
+
+def _extend_breadcrumbs(breadcrumbs: Optional[str], key: Union[int, str]):
+    if isinstance(key, str):
+        if not breadcrumbs:
+            breadcrumbs = key
+        else:
+            breadcrumbs += f".{key}"
+    else:
+        assert isinstance(key, int)
+        item = f"[{key}]"
+        if not breadcrumbs:
+            breadcrumbs = item
+        else:
+            breadcrumbs += item
+    return breadcrumbs
+
+
 @attrs.define
 class Item(_ItemBase):
     def __attrs_post_init__(self):
         self._unknown_fields_dict = {}
 
     @classmethod
-    def from_dict(cls, item: Optional[Dict]):
+    def from_dict(cls, item: Optional[Dict], *, breadcrumbs: Breadcrumbs = None):
         """Read an item from a dictionary."""
         if not item:
             return None
 
-        item = cls._apply_field_types_to_sub_fields(item)
+        if not isinstance(item, dict):
+            path = _get_import_path(cls)
+            if not breadcrumbs:
+                prefix = "Expected"
+            else:
+                prefix = f"Expected {breadcrumbs} to be"
+            raise ValueError(f"{prefix} a dict with fields from {path}, got {item!r}.")
+
+        item = cls._apply_field_types_to_sub_fields(item, breadcrumbs=breadcrumbs)
         unknown_fields, known_fields = split_in_unknown_and_known_fields(item, cls)
         obj = cls(**known_fields)  # type: ignore
         obj._unknown_fields_dict = unknown_fields
         return obj
 
     @classmethod
-    def from_list(cls, items: Optional[List[Dict]]) -> List:
+    def from_list(
+        cls, items: Optional[List[Dict]], *, breadcrumbs: Breadcrumbs = None
+    ) -> List:
         """Read items from a list."""
-        return [cls.from_dict(item) for item in items or []]
+        result = []
+        for index, item in enumerate(items or []):
+            index_breadcrumbs = _extend_breadcrumbs(breadcrumbs, index)
+            result.append(cls.from_dict(item, breadcrumbs=index_breadcrumbs))
+        return result
 
     @classmethod
-    def _apply_field_types_to_sub_fields(cls, item: Dict):
+    def _apply_field_types_to_sub_fields(
+        cls, item: Dict, breadcrumbs: Breadcrumbs = None
+    ):
         """This applies the correct data container class for some of the fields
         that need them.
 
@@ -83,19 +121,30 @@ class Item(_ItemBase):
         annotations = ChainMap(
             *(c.__annotations__ for c in cls.__mro__ if "__annotations__" in c.__dict__)
         )
-
         for field, type_annotation in annotations.items():
             origin = get_origin(type_annotation)
+            is_optional = False
             if origin == Union:
                 field_classes = get_args(type_annotation)
                 if len(field_classes) != 2 or not isinstance(None, field_classes[1]):
+                    field_breadcrumbs = f"{_get_import_path(cls)}.{field}"
                     raise ValueError(
-                        "Field should only be annotated with one type (or optional)."
+                        f"{field_breadcrumbs} is annotated with "
+                        f"{type_annotation}. Fields should only be annotated "
+                        f"with one type (or optional)."
                     )
+                if len(field_classes) == 2 and isinstance(None, field_classes[1]):
+                    is_optional = True
                 type_annotation = field_classes[0]
                 origin = get_origin(type_annotation)
 
             if origin is list:
+                value = item.get(field)
+                if not isinstance(value, list) and not (is_optional and value is None):
+                    field_breadcrumbs = _extend_breadcrumbs(breadcrumbs, field)
+                    raise ValueError(
+                        f"Expected {field_breadcrumbs} to be a list, got " f"{value!r}."
+                    )
                 type_annotation = get_args(type_annotation)[0]
                 if is_data_container(type_annotation):
                     from_list[field] = type_annotation
@@ -105,22 +154,24 @@ class Item(_ItemBase):
         if from_dict or from_list:
             item = dict(**item)
             for key, cls in (from_dict or {}).items():
+                key_breadcrumbs = _extend_breadcrumbs(breadcrumbs, key)
                 value = item.get(key)
                 if value is not None and not isinstance(value, dict):
-                    path = f"{cls.__module__}.{cls.__qualname__}"
+                    path = _get_import_path(cls)
                     raise ValueError(
-                        f"Expected {key!r} to be a dict with fields from "
-                        f"{path}, got {value!r}."
-                    )
-                item[key] = cls.from_dict(value)
-            for key, cls in (from_list or {}).items():
-                value = item.get(key)
-                if value is not None and not isinstance(value, list):
-                    path = f"{cls.__module__}.{cls.__qualname__}"
-                    raise ValueError(
-                        f"Expected {key!r} to be a list of dicts with fields "
+                        f"Expected {key_breadcrumbs} to be a dict with fields "
                         f"from {path}, got {value!r}."
                     )
-                item[key] = cls.from_list(value)
+                item[key] = cls.from_dict(value, breadcrumbs=key_breadcrumbs)
+            for key, cls in (from_list or {}).items():
+                key_breadcrumbs = _extend_breadcrumbs(breadcrumbs, key)
+                value = item.get(key)
+                if value is not None and not isinstance(value, list):
+                    path = _get_import_path(cls)
+                    raise ValueError(
+                        f"Expected {key_breadcrumbs} to be a list of dicts "
+                        f"with fields from {path}, got {value!r}."
+                    )
+                item[key] = cls.from_list(value, breadcrumbs=key_breadcrumbs)
 
         return item

--- a/zyte_common_items/base.py
+++ b/zyte_common_items/base.py
@@ -44,7 +44,7 @@ def _get_import_path(obj: type):
     return f"{obj.__module__}.{obj.__qualname__}"
 
 
-def _extend_breadcrumbs(breadcrumbs: Optional[str], key: Union[int, str]):
+def _extend_breadcrumbs(breadcrumbs: Breadcrumbs, key: Union[int, str]):
     if isinstance(key, str):
         if not breadcrumbs:
             breadcrumbs = key

--- a/zyte_common_items/base.py
+++ b/zyte_common_items/base.py
@@ -67,6 +67,7 @@ class Item(_ItemBase):
 
     @classmethod
     def from_dict(cls, item: Optional[Dict]):
+        """Read an item from a dictionary."""
         return cls._from_dict(item)
 
     @classmethod
@@ -91,6 +92,7 @@ class Item(_ItemBase):
 
     @classmethod
     def from_list(cls, items: Optional[List[Dict]], *, trail: _Trail = None) -> List:
+        """Read items from a list."""
         return cls._from_list(items)
 
     @classmethod

--- a/zyte_common_items/base.py
+++ b/zyte_common_items/base.py
@@ -113,7 +113,7 @@ class Item(_ItemBase):
         data container class based on the type annotations. This could handle both
         ``list`` and ``object`` type requirements. For example:
 
-            * Article having ``trail: List[Breadcrumb]``
+            * Article having ``breadcrumbs: List[Breadcrumb]``
             * Product having ``brand: Optional[Brand]``
 
         Moreover, fields that are not defined to be part of data container

--- a/zyte_common_items/base.py
+++ b/zyte_common_items/base.py
@@ -127,14 +127,15 @@ class Item(_ItemBase):
             if origin == Union:
                 field_classes = get_args(type_annotation)
                 if len(field_classes) != 2 or not isinstance(None, field_classes[1]):
-                    field_breadcrumbs = f"{_get_import_path(cls)}.{field}"
+                    path = f"{_get_import_path(cls)}.{field}"
                     raise ValueError(
-                        f"{field_breadcrumbs} is annotated with "
-                        f"{type_annotation}. Fields should only be annotated "
-                        f"with one type (or optional)."
+                        f"{path} is annotated with {type_annotation}. Fields "
+                        f"should only be annotated with one type (or "
+                        f"optional)."
                     )
-                if len(field_classes) == 2 and isinstance(None, field_classes[1]):
-                    is_optional = True
+                is_optional = len(field_classes) == 2 and isinstance(
+                    None, field_classes[1]
+                )
                 type_annotation = field_classes[0]
                 origin = get_origin(type_annotation)
 


### PR DESCRIPTION
Originally reported by @amanullahawan97.

Given:

```python
from zyte_common_items import Product


Product.from_dict(
    {
        "url": "https://example.com",
        "variants": [{"images": ["https://example.com/a.png"]}],
    }
)
```

Before:

```
Traceback (most recent call last):
  File "test.py", line 4, in <module>
    Product.from_dict(
  File "venv/lib/python3.10/site-packages/zyte_common_items/base.py", line 52, in from_dict
    item = cls._apply_field_types_to_sub_fields(item)
  File "venv/lib/python3.10/site-packages/zyte_common_items/base.py", line 124, in _apply_field_types_to_sub_fields
    item[key] = cls.from_list(value)
  File "venv/lib/python3.10/site-packages/zyte_common_items/base.py", line 61, in from_list
    return [cls.from_dict(item) for item in items or []]
  File "venv/lib/python3.10/site-packages/zyte_common_items/base.py", line 61, in <listcomp>
    return [cls.from_dict(item) for item in items or []]
  File "venv/lib/python3.10/site-packages/zyte_common_items/base.py", line 52, in from_dict
    item = cls._apply_field_types_to_sub_fields(item)
  File "venv/lib/python3.10/site-packages/zyte_common_items/base.py", line 124, in _apply_field_types_to_sub_fields
    item[key] = cls.from_list(value)
  File "venv/lib/python3.10/site-packages/zyte_common_items/base.py", line 61, in from_list
    return [cls.from_dict(item) for item in items or []]
  File "venv/lib/python3.10/site-packages/zyte_common_items/base.py", line 61, in <listcomp>
    return [cls.from_dict(item) for item in items or []]
  File "venv/lib/python3.10/site-packages/zyte_common_items/base.py", line 53, in from_dict
    unknown_fields, known_fields = split_in_unknown_and_known_fields(item, cls)
  File "venv/lib/python3.10/site-packages/zyte_common_items/util.py", line 24, in split_in_unknown_and_known_fields
    unknown, known = split_dict(data, lambda k: k in CLASS_ATTRS[item_cls])
  File "venv/lib/python3.10/site-packages/zyte_common_items/util.py", line 40, in split_dict
    for k, v in dict.items():
AttributeError: 'str' object has no attribute 'items'
```

After:

```
Traceback (most recent call last):
  File "test.py", line 4, in <module>
    Product.from_dict(
  File "venv/lib/python3.10/site-packages/zyte_common_items/base.py", line 82, in from_dict
    item = cls._apply_field_types_to_sub_fields(item, breadcrumbs=breadcrumbs)
  File "venv/lib/python3.10/site-packages/zyte_common_items/base.py", line 175, in _apply_field_types_to_sub_fields
    item[key] = cls.from_list(value, breadcrumbs=key_breadcrumbs)
  File "venv/lib/python3.10/site-packages/zyte_common_items/base.py", line 96, in from_list
    result.append(cls.from_dict(item, breadcrumbs=index_breadcrumbs))
  File "venv/lib/python3.10/site-packages/zyte_common_items/base.py", line 82, in from_dict
    item = cls._apply_field_types_to_sub_fields(item, breadcrumbs=breadcrumbs)
  File "venv/lib/python3.10/site-packages/zyte_common_items/base.py", line 175, in _apply_field_types_to_sub_fields
    item[key] = cls.from_list(value, breadcrumbs=key_breadcrumbs)
  File "venv/lib/python3.10/site-packages/zyte_common_items/base.py", line 96, in from_list
    result.append(cls.from_dict(item, breadcrumbs=index_breadcrumbs))
  File "venv/lib/python3.10/site-packages/zyte_common_items/base.py", line 80, in from_dict
    raise ValueError(f"{prefix} a dict with fields from {path}, got {item!r}.")
ValueError: Expected variants[0].images[0] to be a dict with fields from zyte_common_items.components.Image, got 'https://example.com/a.png'.
```