### PR TITLE
helper method: get_probability()

### DIFF
--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -115,7 +115,7 @@ def test_probability_request():
         headers=headers,
         metadata=ProbabilityMetadata(probability=0.5),
     )
-    assert request.probability == 0.5
+    assert request.get_probability() == 0.5
 
     request = ProbabilityRequest(
         name="Get with RequestURL object",
@@ -123,7 +123,7 @@ def test_probability_request():
     )
 
     assert request.url == "https://example.com/test"
-    assert request.probability is None
+    assert request.get_probability() is None
 
 
 def test_request():

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -123,7 +123,7 @@ def test_probability_request():
     )
 
     assert request.url == "https://example.com/test"
-    assert request.probability == None
+    assert request.probability is None
 
 
 def test_request():

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -107,7 +107,7 @@ def test_probability_request():
         Header(name="Content-Type", value="application/x-www-form-urlencoded"),
         Header(name="Host", value="foo.example"),
     ]
-    ProbabilityRequest(
+    request = ProbabilityRequest(
         name="Post Test",
         url="https://example.com/test",
         method="POST",
@@ -115,6 +115,7 @@ def test_probability_request():
         headers=headers,
         metadata=ProbabilityMetadata(probability=0.5),
     )
+    assert request.probability == 0.5
 
     request = ProbabilityRequest(
         name="Get with RequestURL object",
@@ -122,6 +123,7 @@ def test_probability_request():
     )
 
     assert request.url == "https://example.com/test"
+    assert request.probability == None
 
 
 def test_request():

--- a/zyte_common_items/components.py
+++ b/zyte_common_items/components.py
@@ -455,7 +455,7 @@ class Request(Item):
             method=self.method or "GET",
             headers=header_list,
             body=self.body_bytes,
-            **kwargs
+            **kwargs,
         )
 
 
@@ -484,6 +484,11 @@ class ProbabilityRequest(Request):
 
     #: Data extraction process metadata.
     metadata: Optional[ProbabilityMetadata] = None
+
+    @property
+    def probability(self) -> Optional[int]:
+        if metadata := getattr(self, "metadata", None):
+            return metadata.probability
 
 
 @attrs.define(kw_only=True)

--- a/zyte_common_items/components.py
+++ b/zyte_common_items/components.py
@@ -485,8 +485,7 @@ class ProbabilityRequest(Request):
     #: Data extraction process metadata.
     metadata: Optional[ProbabilityMetadata] = None
 
-    @property
-    def probability(self) -> Optional[int]:
+    def get_probability(self) -> Optional[int]:
         if metadata := getattr(self, "metadata", None):
             return metadata.probability
 


### PR DESCRIPTION
This makes it _slightly_ easier to access the probability value in the spider. It also avoids the redundant code that checks if metadata is present in case the instance is a `Request` and not a `ProbabilityRequest`.