### PR TITLE
new ProbabilityMixin class with get_probability() on items

### DIFF
--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -791,16 +791,17 @@ def test_job_posting_missing_fields():
     "cls,has_proba",
     (
         (Article, True),
-        (ArticleList, False),
         (ArticleFromList, True),
+        (ArticleList, False),
+        (ArticleNavigation, False),
+        (BusinessPlace, True),
+        (JobPosting, True),
         (Product, True),
         (ProductFromList, True),
         (ProductList, False),
-        (BusinessPlace, True),
-        (RealEstate, True),
         (ProductNavigation, False),
-        (ArticleNavigation, False),
-        (JobPosting, True),
+        (ProductVariant, False),
+        (RealEstate, True),
     ),
 )
 def test_get_probability_request(cls, has_proba):

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -815,3 +815,9 @@ def test_get_probability_request(cls, has_proba):
         assert item.get_probability() == 0.5
     else:
         assert item.get_probability() is None
+
+    item = cls.from_dict({**data, "metadata": {"probability": 0.0}})
+    if has_proba:
+        assert item.get_probability() == 0.0
+    else:
+        assert item.get_probability() is None

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -785,3 +785,32 @@ def test_job_posting_missing_fields():
         del incomplete_kwargs[required_field]
         with pytest.raises(TypeError):
             JobPosting(**incomplete_kwargs)
+
+
+@pytest.mark.parametrize(
+    "cls,has_proba",
+    (
+        (Article, True),
+        (ArticleList, False),
+        (ArticleFromList, True),
+        (Product, True),
+        (ProductFromList, True),
+        (ProductList, False),
+        (BusinessPlace, True),
+        (RealEstate, True),
+        (ProductNavigation, False),
+        (ArticleNavigation, False),
+        (JobPosting, True),
+    ),
+)
+def test_get_probability_request(cls, has_proba):
+    data = {"url": "https://example.com"}
+
+    item = cls.from_dict(data)
+    assert item.get_probability() is None
+
+    item = cls.from_dict({**data, "metadata": {"probability": 0.5}})
+    if has_proba:
+        assert item.get_probability() == 0.5
+    else:
+        assert item.get_probability() is None

--- a/tests/test_pages.py
+++ b/tests/test_pages.py
@@ -216,11 +216,14 @@ def check_default_metadata(cls, kwargs, item_name):
     assert type(obj.metadata) == metadata_cls
 
     expected_fields = METADATA_FIELDS[item_name]
-    actual_fields = {
-        field
-        for field in dir(obj.metadata)
-        if not field.startswith("_") and not field.startswith("from_")
-    }
+
+    def allow_field(field_name):
+        for prefix in ["_", "from_", "get_"]:
+            if field_name.startswith(prefix):
+                return False
+        return True
+
+    actual_fields = {field for field in dir(obj.metadata) if allow_field(field)}
     error_message = (
         f"{metadata_cls}: actual fields ({actual_fields}) != expected fields "
         f"({expected_fields})"

--- a/zyte_common_items/base.py
+++ b/zyte_common_items/base.py
@@ -51,8 +51,7 @@ def _extend_trail(trail: _Trail, key: Union[int, str]):
 class ProbabilityMixin:
     def get_probability(self) -> Optional[float]:
         if metadata := getattr(self, "metadata", None):
-            if probability := getattr(metadata, "probability", None):
-                return probability
+            return getattr(metadata, "probability", None)
         return None
 
 

--- a/zyte_common_items/base.py
+++ b/zyte_common_items/base.py
@@ -48,7 +48,16 @@ def _extend_trail(trail: _Trail, key: Union[int, str]):
 
 
 @attrs.define
-class Item(_ItemBase):
+class ProbabilityMixin:
+    def get_probability(self) -> Optional[float]:
+        if metadata := getattr(self, "metadata", None):
+            if probability := getattr(metadata, "probability", None):
+                return probability
+        return None
+
+
+@attrs.define
+class Item(ProbabilityMixin, _ItemBase):
     def __attrs_post_init__(self):
         self._unknown_fields_dict = {}
 

--- a/zyte_common_items/components.py
+++ b/zyte_common_items/components.py
@@ -4,7 +4,7 @@ from typing import List, Optional, Type
 
 import attrs
 
-from zyte_common_items.base import Item
+from zyte_common_items.base import Item, ProbabilityMixin
 from zyte_common_items.util import convert_to_class, url_to_str
 
 # Metadata ####################################################################
@@ -479,15 +479,11 @@ def request_list_processor(request_list):
 
 
 @attrs.define(kw_only=True)
-class ProbabilityRequest(Request):
+class ProbabilityRequest(Request, ProbabilityMixin):
     """A :class:`Request` that includes a probability value."""
 
     #: Data extraction process metadata.
     metadata: Optional[ProbabilityMetadata] = None
-
-    def get_probability(self) -> Optional[int]:
-        if metadata := getattr(self, "metadata", None):
-            return metadata.probability
 
 
 @attrs.define(kw_only=True)


### PR DESCRIPTION
Related to https://github.com/zytedata/zyte-common-items/pull/64, it would seem it's beneficial to extend `get_probability()` on item instances as well.

**Motivation:** In a spider callback, it's easier to do something like:

```python
def parse_item(self, response, item: Product):
    probability = item.get_probability()
    if probability and probability >= 0.1:
        yield item
```

than:

```python
def parse_item(self, response, item: Product):
    probability = None
    if metadata := getattr(item, "metadata", None):
        probability = metadata.probability

    if probability and probability >= 0.1:
        yield item
```