### PR TITLE
Search requests (no-templates approach)

### DIFF
--- a/tests/test_request_templates.py
+++ b/tests/test_request_templates.py
@@ -1,0 +1,94 @@
+from urllib.parse import quote, quote_plus
+
+import attrs
+import pytest
+from web_poet import ItemPage, PageParams, RequestUrl, field
+
+from zyte_common_items.items import SearchRequest
+
+
+@attrs.define
+class UnquotedSearchRequestPage(ItemPage[SearchRequest]):
+    page_params: PageParams
+
+    @field
+    def url(self):
+        return f"https://example.com/?search={self.page_params['keyword']}"
+
+
+@attrs.define
+class QuoteSearchRequestPage(ItemPage[SearchRequest]):
+    page_params: PageParams
+
+    @field
+    def url(self):
+        return f"https://example.com/?search={quote(self.page_params['keyword'])}"
+
+
+@attrs.define
+class QuotePlusSearchRequestPage(ItemPage[SearchRequest]):
+    page_params: PageParams
+
+    @field
+    def url(self):
+        return f"https://example.com/?search={quote_plus(self.page_params['keyword'])}"
+
+
+@attrs.define
+class CustomFilterSearchRequestPage(ItemPage[SearchRequest]):
+    page_params: PageParams
+
+    @field
+    def url(self):
+        return f"https://example.com/?search={self.page_params['keyword']} baz"
+
+
+@attrs.define
+class UrlBasedSearchRequestPage(ItemPage[SearchRequest]):
+    page_params: PageParams
+    request_url: RequestUrl
+
+    @field
+    def url(self):
+        return f"{self.request_url}?search={quote(self.page_params['keyword'])}"
+
+
+@pytest.mark.parametrize(
+    ("page", "inputs", "keyword", "url"),
+    (
+        (
+            UnquotedSearchRequestPage,
+            {},
+            "foo bar",
+            "https://example.com/?search=foo bar",
+        ),
+        (
+            QuoteSearchRequestPage,
+            {},
+            "foo bar",
+            "https://example.com/?search=foo%20bar",
+        ),
+        (
+            QuotePlusSearchRequestPage,
+            {},
+            "foo bar",
+            "https://example.com/?search=foo+bar",
+        ),
+        (
+            CustomFilterSearchRequestPage,
+            {},
+            "foo bar",
+            "https://example.com/?search=foo bar baz",
+        ),
+        (
+            UrlBasedSearchRequestPage,
+            {"request_url": RequestUrl("https://foo.example/")},
+            "foo bar",
+            "https://foo.example/?search=foo%20bar",
+        ),
+    ),
+)
+@pytest.mark.asyncio
+async def test_url(page, inputs, keyword, url):
+    search_request = await page(**inputs, page_params={"keyword": keyword}).to_item()
+    assert search_request.url == url

--- a/zyte_common_items/items.py
+++ b/zyte_common_items/items.py
@@ -1202,3 +1202,8 @@ class SocialMediaPost(Item):
     metadata: Optional[SocialMediaPostMetadata] = attrs.field(
         default=None, converter=attrs.converters.optional(MetadataCaster(SocialMediaPostMetadata)), kw_only=True  # type: ignore
     )
+
+
+@attrs.define(kw_only=True)
+class SearchRequest(Request):
+    url: str

--- a/zyte_common_items/items.py
+++ b/zyte_common_items/items.py
@@ -1206,4 +1206,4 @@ class SocialMediaPost(Item):
 
 @attrs.define(kw_only=True)
 class SearchRequest(Request):
-    url: str
+    pass

--- a/zyte_common_items/pages.py
+++ b/zyte_common_items/pages.py
@@ -63,6 +63,7 @@ from .items import (
     ProductNavigation,
     ProductVariant,
     RealEstate,
+    SearchRequest,
     SocialMediaPost,
 )
 from .processors import (
@@ -1114,3 +1115,7 @@ class AutoSocialMediaPostPage(BaseSocialMediaPostPage):
     @field
     def metadata(self) -> Optional[SocialMediaPostMetadata]:
         return self.social_media_post.metadata
+
+
+class SearchRequestPage(ItemPage[SearchRequest]):
+    pass


### PR DESCRIPTION
Alternative to https://github.com/zytedata/zyte-common-items/pull/80 that does not rely on templates.

This approach is meant to support the following syntax:

```python
# web-poet example implementation
search_request = get_item(
    "https://books.toscrape.com/",
    SearchRequest,
    page_params={"keyword": "foo"},
)
search_result = get_item(
    search_request.url,
    BookList,
)

# scrapy-poet
def start_requests(self):
    for keyword in self.keywords:
        yield Request(
            "https://example.com",
            meta={
                "page_params": {
                    "keyword": keyword,
                }
            },
        )

def parse(self, response: DummyResponse, search_request: SearchRequest):
    yield search_request.to_scrapy(self.parse_search_results)
```

The main advantage I see over https://github.com/zytedata/zyte-common-items/pull/80 is that there is no limit in how to implement the building of a request (e.g. you can parse the request URL and build the search URL with a different logic depending on it), at the cost of worse readability for the most common scenarios. Although we can probably improve readability with default processors implementing template support if we want.

Also, and this is true for both #80 and #81, we could potentially support in the future a way to allow removing 1 callback from the implementation if we allow specifying `SearchRequest` in the request meta, and have the provider resolve the request, e.g.
```python
# web-poet example implementation
search_result = get_item(
    "https://books.toscrape.com/",
    BookList,
    request=SearchRequest,
    request_params={"keyword": "foo"},
)

# scrapy-poet
def start_requests(self):
    for keyword in self.keywords:
        yield Request(
            "https://example.com",
            meta={
                "poet_request": SearchRequest,
                "poet_request_params": {
                    "keyword": keyword,
                }
            },
        )
```