### PR TITLE
add 'notes' to Request

### DIFF
--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -143,12 +143,12 @@ def test_probability_request():
     request = ProbabilityRequest(
         name="Get with RequestURL object",
         url=RequestUrl("https://example.com/test"),
-        notes=["arbitrary", "info"],
+        notes={"type": "test request", "id": 782},
     )
 
     assert request.url == "https://example.com/test"
     assert request.get_probability() is None
-    assert request.notes == ["arbitrary", "info"]
+    assert request.notes == {"type": "test request", "id": 782}
 
 
 def test_request():
@@ -169,10 +169,10 @@ def test_request():
     request = Request(
         name="Get with RequestURL object",
         url=RequestUrl("https://example.com/test"),
-        notes=["arbitrary", "info"],
+        notes={"type": "test request", "id": 782},
     )
     assert request.url == "https://example.com/test"
-    assert request.notes == ["arbitrary", "info"]
+    assert request.notes == {"type": "test request", "id": 782}
 
 
 def test_job_location():

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -138,14 +138,17 @@ def test_probability_request():
         metadata=ProbabilityMetadata(probability=0.5),
     )
     assert request.get_probability() == 0.5
+    assert request.notes is None
 
     request = ProbabilityRequest(
         name="Get with RequestURL object",
         url=RequestUrl("https://example.com/test"),
+        notes=["arbitrary", "info"],
     )
 
     assert request.url == "https://example.com/test"
     assert request.get_probability() is None
+    assert request.notes == ["arbitrary", "info"]
 
 
 def test_request():
@@ -154,20 +157,22 @@ def test_request():
         Header(name="Content-Type", value="application/x-www-form-urlencoded"),
         Header(name="Host", value="foo.example"),
     ]
-    Request(
+    request = Request(
         name="Post Test",
         url="https://example.com/test",
         method="POST",
         body="ZmllbGQxPXZhbHVlMSZmaWVsZDI9dmFsdWUy",
         headers=headers,
     )
+    assert request.notes is None
 
     request = Request(
         name="Get with RequestURL object",
         url=RequestUrl("https://example.com/test"),
+        notes=["arbitrary", "info"],
     )
-
     assert request.url == "https://example.com/test"
+    assert request.notes == ["arbitrary", "info"]
 
 
 def test_job_location():

--- a/zyte_common_items/components/request.py
+++ b/zyte_common_items/components/request.py
@@ -1,5 +1,5 @@
 import base64
-from typing import List, Optional, Type, TypeVar
+from typing import Any, Dict, List, Optional, Type, TypeVar
 
 import attrs
 
@@ -43,7 +43,7 @@ class Request(Item):
     name: Optional[str] = None
 
     #: Arbitrary list of information about the request.
-    notes: Optional[List[str]] = None
+    notes: Optional[Dict[str, Any]] = None
 
     _body_bytes = None
 

--- a/zyte_common_items/components/request.py
+++ b/zyte_common_items/components/request.py
@@ -42,6 +42,9 @@ class Request(Item):
     #: Name of the page being requested.
     name: Optional[str] = None
 
+    #: Arbitrary list of information about the request.
+    notes: Optional[List[str]] = None
+
     _body_bytes = None
 
     @property


### PR DESCRIPTION
A proposal to add some way of putting some kind of information to the Request.

One use case is adding some identifiers to a given request. For example, in https://github.com/zytedata/zyte-spider-templates/blob/main/zyte_spider_templates/pages/product_navigation_heuristics.py#L72, a current workaround would be to add some kind of _url prefix_ to `request.name`.

It's not pretty but it does the job. However, it'd be hard to properly identify some information here.

It'd be nice if we have some dedicated field to put such arbitrary values. This would be quite useful when developers create page objects with some added notes to the `Request`s.
