### PR TITLE
Processor changes

### DIFF
--- a/tests/test_pages_price.py
+++ b/tests/test_pages_price.py
@@ -62,21 +62,21 @@ async def test_price_explicit():
     url = "https://example.com"
     page = CustomProductPage(response=HttpResponse(url=url, body=html))
     assert page.call_count == 0
-    assert page.price == "13.20"
+    assert page.price == "$13.2"
     assert page.call_count == 1
     assert page.currency is None
-    assert await page.currencyRaw == "$"
-    assert page.call_count == 1  # we want this to be 1
-    assert await page.currencyRaw == "$"
-    assert page.call_count == 1  # we want this to be 1
+    assert await page.currencyRaw is None
+    assert page.call_count == 2  # we want this to be 1
+    assert await page.currencyRaw is None
+    assert page.call_count == 2  # we want this to be 1
 
     # access currency fields before the price field
     page = CustomProductPage(response=HttpResponse(url=url, body=html))
     assert page.call_count == 0
     assert page.currency is None
-    assert await page.currencyRaw == "$"
+    assert await page.currencyRaw is None
     assert page.call_count == 1
-    assert page.price == "13.20"
+    assert page.price == "$13.2"
     assert page.call_count == 2  # we want this to be 1
 
 

--- a/tests/test_pages_price.py
+++ b/tests/test_pages_price.py
@@ -62,21 +62,21 @@ async def test_price_explicit():
     url = "https://example.com"
     page = CustomProductPage(response=HttpResponse(url=url, body=html))
     assert page.call_count == 0
-    assert page.price == "$13.2"
+    assert page.price == "13.20"
     assert page.call_count == 1
     assert page.currency is None
-    assert await page.currencyRaw is None
-    assert page.call_count == 2  # we want this to be 1
-    assert await page.currencyRaw is None
-    assert page.call_count == 2  # we want this to be 1
+    assert await page.currencyRaw == "$"
+    assert page.call_count == 1  # we want this to be 1
+    assert await page.currencyRaw == "$"
+    assert page.call_count == 1  # we want this to be 1
 
     # access currency fields before the price field
     page = CustomProductPage(response=HttpResponse(url=url, body=html))
     assert page.call_count == 0
     assert page.currency is None
-    assert await page.currencyRaw is None
+    assert await page.currencyRaw == "$"
     assert page.call_count == 1
-    assert page.price == "$13.2"
+    assert page.price == "13.20"
     assert page.call_count == 2  # we want this to be 1
 
 

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -136,7 +136,9 @@ def test_breadcrumbs_base_url():
     [
         (None, None),
         ("", None),
+        (" ", None),
         ("foo", Brand(name="foo")),
+        (" foo ", Brand(name="foo")),
         (Selector(text="<html></html>"), None),
         (SelectorList([]), None),
         (fromstring("<p>foo</p>"), Brand(name="foo")),
@@ -401,6 +403,8 @@ def test_images_page():
         ({}, {}),
         (22.9, "22.90"),
         (22.0, "22.00"),
+        ("22.9", "22.9"),
+        ("Do not apply to strings...", "Do not apply to strings..."),
     ],
 )
 def test_prices(input_value, expected_value):

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -15,7 +15,6 @@ from zyte_common_items import (
     Gtin,
     Image,
     ProductPage,
-    ProductVariant,
 )
 from zyte_common_items.processors import (
     _format_price,
@@ -25,7 +24,6 @@ from zyte_common_items.processors import (
     images_processor,
     price_processor,
     rating_processor,
-    variants_processor
 )
 
 base_url = "http://www.example.com/blog/"
@@ -406,22 +404,3 @@ def test_prices(input_value, expected_value):
 
     page = PricePage(base_url)  # type: ignore[arg-type]
     assert page.price == expected_value
-
-
-@pytest.mark.parametrize(
-    "input_value,expected_value",
-    [
-        (
-            [{"price": "12,12$"}, {"price": 100}],
-            [ProductVariant(price="12.12"), ProductVariant(price="100.00")]
-        ),
-    ],
-)
-def test_variants(input_value, expected_value):
-    class VariantPage(BasePage):
-        @field(out=[variants_processor])
-        def variants(self):
-            return input_value
-
-    page = VariantPage(base_url)  # type: ignore[arg-type]
-    assert page.variants == expected_value

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -382,17 +382,10 @@ def test_images(input_value, expected_value):
 @pytest.mark.parametrize(
     "input_value,expected_value",
     [
-        ("$10", "10.00"),
-        ("100  ", "100.00"),
-        ("100rub", "100.00"),
         (100, "100.00"),
         (None, None),
         ([], []),
         ({}, {}),
-        ("", None),
-        ("buy 10 ab ab", "10.00"),
-        ("1,000.17", "1000.17"),
-        ("1,000", "1000.00"),
         (22.9, "22.90"),
         (22.0, "22.00"),
     ],

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -14,7 +14,6 @@ from zyte_common_items import (
     Breadcrumb,
     Gtin,
     Image,
-    Page,
     ProductPage,
 )
 from zyte_common_items.processors import (
@@ -159,8 +158,8 @@ def test_brand(input_value, expected_value):
 
 
 def test_brand_page():
-    class MyProductPage(Page):
-        @field(out=[brand_processor])
+    class MyProductPage(ProductPage):
+        @field
         def brand(self):
             return self.css("body")
 
@@ -377,6 +376,20 @@ def test_images(input_value, expected_value):
 
     page = ImagesPage(base_url)  # type: ignore[arg-type]
     assert page.images == expected_value
+
+
+def test_images_page():
+    class MyProductPage(ProductPage):
+        @field
+        def images(self):
+            return self.css("img::attr(href)").getall()
+
+    response = HttpResponse(
+        url="http://www.example.com/",
+        body="<html><body><img href='https://www.url.com/img.jpg'></body></html>".encode(),
+    )
+    page = MyProductPage(response=response)
+    assert page.images == [Image(url="https://www.url.com/img.jpg")]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -14,6 +14,7 @@ from zyte_common_items import (
     Breadcrumb,
     Gtin,
     Image,
+    Page,
     ProductPage,
 )
 from zyte_common_items.processors import (
@@ -158,7 +159,7 @@ def test_brand(input_value, expected_value):
 
 
 def test_brand_page():
-    class MyProductPage(BasePage):
+    class MyProductPage(Page):
         @field(out=[brand_processor])
         def brand(self):
             return self.css("body")

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -394,7 +394,7 @@ def test_images(input_value, expected_value):
         ("1,000", "1000.00"),
         (22.9, "22.90"),
         (22.0, "22.00"),
-    ]
+    ],
 )
 def test_prices(input_value, expected_value):
     class PricePage(BasePage):

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -7,12 +7,22 @@ from zyte_parsers import Breadcrumb as zp_Breadcrumb
 from zyte_parsers import Gtin as zp_Gtin
 from zyte_parsers import extract_breadcrumbs
 
-from zyte_common_items import AggregateRating, BasePage, Breadcrumb, Gtin, ProductPage
+from zyte_common_items import (
+    AggregateRating,
+    BasePage,
+    Brand,
+    Breadcrumb,
+    Gtin,
+    Image,
+    ProductPage,
+)
 from zyte_common_items.processors import (
     _format_price,
     brand_processor,
     breadcrumbs_processor,
     gtin_processor,
+    images_processor,
+    price_processor,
     rating_processor,
 )
 
@@ -125,16 +135,16 @@ def test_breadcrumbs_base_url():
     "input_value,expected_value",
     [
         (None, None),
-        ("", ""),
-        ("foo", "foo"),
+        ("", None),
+        ("foo", Brand(name="foo")),
         (Selector(text="<html></html>"), None),
         (SelectorList([]), None),
-        (fromstring("<p>foo</p>"), "foo"),
-        (fromstring("<img alt='foo'>"), "foo"),
-        (fromstring("<p><img alt='foo'></p>"), "foo"),
-        (fromstring("<p><p><img alt='foo'></p></p>"), "foo"),
-        (Selector(text="<p>foo</p>"), "foo"),
-        (SelectorList([Selector(text="<p>foo</p>")]), "foo"),
+        (fromstring("<p>foo</p>"), Brand(name="foo")),
+        (fromstring("<img alt='foo'>"), Brand(name="foo")),
+        (fromstring("<p><img alt='foo'></p>"), Brand(name="foo")),
+        (fromstring("<p><p><img alt='foo'></p></p>"), Brand(name="foo")),
+        (Selector(text="<p>foo</p>"), Brand(name="foo")),
+        (SelectorList([Selector(text="<p>foo</p>")]), Brand(name="foo")),
     ],
 )
 def test_brand(input_value, expected_value):
@@ -149,7 +159,7 @@ def test_brand(input_value, expected_value):
 
 def test_brand_page():
     class MyProductPage(ProductPage):
-        @field
+        @field(out=[brand_processor])
         def brand(self):
             return self.css("body")
 
@@ -158,7 +168,7 @@ def test_brand_page():
         body="<html><body><img alt='foo'></body></html>".encode(),
     )
     page = MyProductPage(response=response)
-    assert page.brand == "foo"
+    assert page.brand == Brand(name="foo")
 
 
 @pytest.mark.parametrize(
@@ -321,3 +331,76 @@ def test_rating_3_values():
     assert page.aggregateRating == AggregateRating(
         ratingValue=3.8, bestRating=10, reviewCount=5
     )
+
+
+@pytest.mark.parametrize(
+    "input_value,expected_value",
+    [
+        (None, None),
+        ([], []),
+        ("https://www.url.com/img.jpg", [Image(url="https://www.url.com/img.jpg")]),
+        (
+            [
+                Image("https://www.url.com/img1.jpg"),
+                Image("https://www.url.com/img2.jpg"),
+            ],
+            [
+                Image("https://www.url.com/img1.jpg"),
+                Image("https://www.url.com/img2.jpg"),
+            ],
+        ),
+        (
+            ["https://www.url.com/img1.jpg", "https://www.url.com/img2.jpg"],
+            [
+                Image("https://www.url.com/img1.jpg"),
+                Image("https://www.url.com/img2.jpg"),
+            ],
+        ),
+        (
+            [
+                {"url": "https://www.url.com/img1.jpg"},
+                {"url": "https://www.url.com/img2.jpg"},
+            ],
+            [
+                Image("https://www.url.com/img1.jpg"),
+                Image("https://www.url.com/img2.jpg"),
+            ],
+        ),
+    ],
+)
+def test_images(input_value, expected_value):
+    class ImagesPage(BasePage):
+        @field(out=[images_processor])
+        def images(self):
+            return input_value
+
+    page = ImagesPage(base_url)  # type: ignore[arg-type]
+    assert page.images == expected_value
+
+
+@pytest.mark.parametrize(
+    "input_value,expected_value",
+    [
+        ("$10", "10.00"),
+        ("100  ", "100.00"),
+        ("100rub", "100.00"),
+        (100, "100.00"),
+        (None, None),
+        ([], []),
+        ({}, {}),
+        ("", None),
+        ("buy 10 ab ab", "10.00"),
+        ("1,000.17", "1000.17"),
+        ("1,000", "1000.00"),
+        (22.9, "22.90"),
+        (22.0, "22.00"),
+    ]
+)
+def test_prices(input_value, expected_value):
+    class PricePage(BasePage):
+        @field(out=[price_processor])
+        def price(self):
+            return input_value
+
+    page = PricePage(base_url)  # type: ignore[arg-type]
+    assert page.price == expected_value

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -158,7 +158,7 @@ def test_brand(input_value, expected_value):
 
 
 def test_brand_page():
-    class MyProductPage(ProductPage):
+    class MyProductPage(BasePage):
         @field(out=[brand_processor])
         def brand(self):
             return self.css("body")

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -15,6 +15,7 @@ from zyte_common_items import (
     Gtin,
     Image,
     ProductPage,
+    ProductVariant,
 )
 from zyte_common_items.processors import (
     _format_price,
@@ -24,6 +25,7 @@ from zyte_common_items.processors import (
     images_processor,
     price_processor,
     rating_processor,
+    variants_processor
 )
 
 base_url = "http://www.example.com/blog/"
@@ -404,3 +406,22 @@ def test_prices(input_value, expected_value):
 
     page = PricePage(base_url)  # type: ignore[arg-type]
     assert page.price == expected_value
+
+
+@pytest.mark.parametrize(
+    "input_value,expected_value",
+    [
+        (
+            [{"price": "12,12$"}, {"price": 100}],
+            [ProductVariant(price="12.12"), ProductVariant(price="100.00")]
+        ),
+    ],
+)
+def test_variants(input_value, expected_value):
+    class VariantPage(BasePage):
+        @field(out=[variants_processor])
+        def variants(self):
+            return input_value
+
+    page = VariantPage(base_url)  # type: ignore[arg-type]
+    assert page.variants == expected_value

--- a/tox.ini
+++ b/tox.ini
@@ -73,7 +73,7 @@ commands = mypy zyte_common_items tests
 [testenv:twinecheck]
 basepython = python3
 deps =
-    twine==4.0.2
+    twine==5.1.1
     build==0.10.0
 commands =
     python -m build --sdist

--- a/zyte_common_items/pages/product.py
+++ b/zyte_common_items/pages/product.py
@@ -23,7 +23,6 @@ from zyte_common_items.processors import (
     price_processor,
     rating_processor,
     simple_price_processor,
-    variants_processor,
 )
 
 from .base import BasePage, Page
@@ -49,7 +48,6 @@ class BaseProductPage(
         price = [price_processor]
         regularPrice = [simple_price_processor]
         images = [images_processor]
-        variants = [variants_processor]
 
 
 class ProductPage(
@@ -67,7 +65,6 @@ class ProductPage(
         price = [price_processor]
         regularPrice = [simple_price_processor]
         images = [images_processor]
-        variants = [variants_processor]
 
 
 @attrs.define

--- a/zyte_common_items/pages/product.py
+++ b/zyte_common_items/pages/product.py
@@ -23,6 +23,7 @@ from zyte_common_items.processors import (
     price_processor,
     rating_processor,
     simple_price_processor,
+    variants_processor,
 )
 
 from .base import BasePage, Page
@@ -48,6 +49,7 @@ class BaseProductPage(
         price = [price_processor]
         regularPrice = [simple_price_processor]
         images = [images_processor]
+        variants = [variants_processor]
 
 
 class ProductPage(
@@ -65,6 +67,7 @@ class ProductPage(
         price = [price_processor]
         regularPrice = [simple_price_processor]
         images = [images_processor]
+        variants = [variants_processor]
 
 
 @attrs.define

--- a/zyte_common_items/pages/product.py
+++ b/zyte_common_items/pages/product.py
@@ -19,6 +19,7 @@ from zyte_common_items.processors import (
     description_html_processor,
     description_processor,
     gtin_processor,
+    images_processor,
     price_processor,
     rating_processor,
     simple_price_processor,
@@ -46,6 +47,7 @@ class BaseProductPage(
         gtin = [gtin_processor]
         price = [price_processor]
         regularPrice = [simple_price_processor]
+        images = [images_processor]
 
 
 class ProductPage(
@@ -62,6 +64,7 @@ class ProductPage(
         gtin = [gtin_processor]
         price = [price_processor]
         regularPrice = [simple_price_processor]
+        images = [images_processor]
 
 
 @attrs.define

--- a/zyte_common_items/processors.py
+++ b/zyte_common_items/processors.py
@@ -29,6 +29,7 @@ from .components import (
     ProbabilityRequest,
     Request,
 )
+from .items import ProductVariant
 
 
 def _get_base_url(page: Any) -> Optional[str]:
@@ -417,3 +418,21 @@ def metadata_processor(metadata: BaseMetadata, page):
     if page.metadata_cls is None:
         return None
     return metadata.cast(page.metadata_cls)
+
+
+def variants_processor(variants: list[Any], page: Any) -> list[ProductVariant]:
+    ret = []
+    for variant in variants:
+        if isinstance(variant, Mapping):
+            processors = {
+                "price": simple_price_processor,
+                "regularPrice": simple_price_processor,
+            }
+            for field, processor in processors.items():
+                if field in variant:
+                    variant[field] = processor(variant[field], page)
+
+            ret.append(ProductVariant(**variant))
+        else:
+            ret.append(variant)
+    return ret

--- a/zyte_common_items/processors.py
+++ b/zyte_common_items/processors.py
@@ -139,7 +139,7 @@ def price_processor(value: Any, page: Any) -> Any:
 
     Supported inputs are :class:`~parsel.selector.Selector`,
     :class:`~parsel.selector.SelectorList`, :class:`~lxml.html.HtmlElement`, string
-    instances and numberic values.
+    instances and numeric values.
 
     Other inputs are returned as is.
 
@@ -166,7 +166,7 @@ def simple_price_processor(value: Any, page: Any) -> Any:
 
     Supported inputs are :class:`~parsel.selector.Selector`,
     :class:`~parsel.selector.SelectorList`, :class:`~lxml.html.HtmlElement`, string
-    instances and numberic values.
+    instances and numeric values.
 
     Other inputs are returned as is.
 

--- a/zyte_common_items/processors.py
+++ b/zyte_common_items/processors.py
@@ -121,6 +121,7 @@ def brand_processor(value: Any, page: Any) -> Any:
     value = _handle_selectorlist(value)
 
     if isinstance(value, str):
+        value = value.strip()
         return Brand(name=value) if value else None
 
     if isinstance(value, (Selector, SelectorList, HtmlElement)):
@@ -372,13 +373,6 @@ def images_processor(value: Any, page: Any) -> Any:
 
     Other inputs are returned unchanged.
     """
-
-    # TODO: add generic-purpose extract_images utility to zyte-parsers
-    #
-    # value = _handle_selectorlist(value)
-    # if isinstance(value, (Selector, HtmlElement)):
-    #    images = extract_images(value)
-    #    return [Image(url=url) for url in images]
 
     if isinstance(value, str):
         return [Image(url=value)]

--- a/zyte_common_items/processors.py
+++ b/zyte_common_items/processors.py
@@ -29,7 +29,6 @@ from .components import (
     ProbabilityRequest,
     Request,
 )
-from .items import ProductVariant
 
 
 def _get_base_url(page: Any) -> Optional[str]:
@@ -418,21 +417,3 @@ def metadata_processor(metadata: BaseMetadata, page):
     if page.metadata_cls is None:
         return None
     return metadata.cast(page.metadata_cls)
-
-
-def variants_processor(variants: list[Any], page: Any) -> list[ProductVariant]:
-    ret = []
-    for variant in variants:
-        if isinstance(variant, Mapping):
-            processors = {
-                "price": simple_price_processor,
-                "regularPrice": simple_price_processor,
-            }
-            for field, processor in processors.items():
-                if field in variant:
-                    variant[field] = processor(variant[field], page)
-
-            ret.append(ProductVariant(**variant))
-        else:
-            ret.append(variant)
-    return ret

--- a/zyte_common_items/processors.py
+++ b/zyte_common_items/processors.py
@@ -147,6 +147,8 @@ def price_processor(value: Any, page: Any) -> Any:
 
     .. _price-parser: https://github.com/scrapinghub/price-parser
     """
+    value = _handle_selectorlist(value)
+
     if isinstance(value, Real):
         return f"{value:.2f}"
     elif isinstance(value, (Selector, HtmlElement, str)):
@@ -170,6 +172,8 @@ def simple_price_processor(value: Any, page: Any) -> Any:
 
     .. _price-parser: https://github.com/scrapinghub/price-parser
     """
+    value = _handle_selectorlist(value)
+
     if isinstance(value, Real):
         return f"{value:.2f}"
     elif isinstance(value, (Selector, HtmlElement, str)):

--- a/zyte_common_items/processors.py
+++ b/zyte_common_items/processors.py
@@ -108,16 +108,16 @@ def breadcrumbs_processor(value: Any, page: Any) -> Any:
     return results
 
 
-def brand_processor(value: Any, page: Any) -> Union[Brand, None]:
+def brand_processor(value: Any, page: Any) -> Any:
     """Convert the data into a brand name if possible.
 
     If inputs are either :class:`~parsel.selector.Selector`,
     :class:`~parsel.selector.SelectorList` or :class:`~lxml.html.HtmlElement`, attempts
     to extract brand data from it.
 
-    If value is a string, use it to create brand object instance
+    If value is a string, uses it to create a :class:`~zyte_common_items.Brand` instance.
 
-    Other inputs are returned unchanged
+    Other inputs are returned unchanged.
     """
     value = _handle_selectorlist(value)
 
@@ -364,7 +364,7 @@ def rating_processor(value: Any, page: Any) -> Any:
     return value
 
 
-def images_processor(value: Any, page: Any) -> List[Image]:
+def images_processor(value: Any, page: Any) -> Any:
     """Convert the data into a list of :class:`~zyte_common_items.Image`
     objects if possible.
 

--- a/zyte_common_items/processors.py
+++ b/zyte_common_items/processors.py
@@ -138,8 +138,7 @@ def price_processor(value: Any, page: Any) -> Any:
     Uses the price-parser_ library.
 
     Supported inputs are :class:`~parsel.selector.Selector`,
-    :class:`~parsel.selector.SelectorList`, :class:`~lxml.html.HtmlElement`, string
-    instances and numeric values.
+    :class:`~parsel.selector.SelectorList`, :class:`~lxml.html.HtmlElement` and numeric values.
 
     Other inputs are returned as is.
 
@@ -151,7 +150,7 @@ def price_processor(value: Any, page: Any) -> Any:
 
     if isinstance(value, Real):
         return f"{value:.2f}"
-    elif isinstance(value, (Selector, HtmlElement, str)):
+    elif isinstance(value, (Selector, HtmlElement)):
         price = extract_price(value)
         page._parsed_price = price
         return _format_price(price)

--- a/zyte_common_items/processors.py
+++ b/zyte_common_items/processors.py
@@ -164,8 +164,7 @@ def simple_price_processor(value: Any, page: Any) -> Any:
     Uses the price-parser_ library.
 
     Supported inputs are :class:`~parsel.selector.Selector`,
-    :class:`~parsel.selector.SelectorList`, :class:`~lxml.html.HtmlElement`, string
-    instances and numeric values.
+    :class:`~parsel.selector.SelectorList`, :class:`~lxml.html.HtmlElement` and numeric values.
 
     Other inputs are returned as is.
 
@@ -175,7 +174,7 @@ def simple_price_processor(value: Any, page: Any) -> Any:
 
     if isinstance(value, Real):
         return f"{value:.2f}"
-    elif isinstance(value, (Selector, HtmlElement, str)):
+    elif isinstance(value, (Selector, HtmlElement)):
         price = extract_price(value)
         return _format_price(price)
     else:

--- a/zyte_common_items/processors.py
+++ b/zyte_common_items/processors.py
@@ -375,10 +375,9 @@ def images_processor(value: Any, page: Any) -> Any:
     Other inputs are returned unchanged.
     """
 
-    value = _handle_selectorlist(value)
-
     # TODO: add generic-purpose extract_images utility to zyte-parsers
     #
+    # value = _handle_selectorlist(value)
     # if isinstance(value, (Selector, HtmlElement)):
     #    images = extract_images(value)
     #    return [Image(url=url) for url in images]


### PR DESCRIPTION
We'd like to remove processors from our utils and replace them with `zyte-common-items` counterparts. There are some functionality missing, however.

Summary of changes:
* Add new processor, `images_processor`, that attempts to convert input to list of `zyte_common_items.Image` instances
* Make `brand_processor` return `zyte_common_items.Brand` instances instead of strings
* Allow `brand_processor` to take string as an input argument
* Allow `price_processor` to take ~~string or~~ number as input argument (resolves https://github.com/zytedata/zyte-common-items/issues/94)