### PR TITLE
Handle numeric values with commas in rating processor

### DIFF
--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -313,6 +313,22 @@ def test_gtin(input_value, expected_value):
             },
             AggregateRating(ratingValue=3.8, bestRating=10.0, reviewCount=3),
         ),
+        (
+            {
+                "ratingValue": "2.12",
+                "bestRating": "5.0",
+                "reviewCount": "12",
+            },
+            AggregateRating(ratingValue=2.12, bestRating=5.0, reviewCount=12),
+        ),
+        (
+            {
+                "ratingValue": "2,12",
+                "bestRating": "5,",
+                "reviewCount": "12",
+            },
+            AggregateRating(ratingValue=2.12, bestRating=5.0, reviewCount=12),
+        ),
     ],
 )
 def test_rating(input_value, expected_value):

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -329,6 +329,14 @@ def test_gtin(input_value, expected_value):
             },
             AggregateRating(ratingValue=2.12, bestRating=5.0, reviewCount=12),
         ),
+        (
+            {
+                "ratingValue": "2.12",
+                "bestRating": "5,",
+                "reviewCount": "12,123",
+            },
+            AggregateRating(ratingValue=2.12, bestRating=5.0, reviewCount=12123),
+        ),
     ],
 )
 def test_rating(input_value, expected_value):

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -324,7 +324,7 @@ def test_gtin(input_value, expected_value):
         (
             {
                 "ratingValue": "2,12",
-                "bestRating": "5,",
+                "bestRating": "5,0",
                 "reviewCount": "12",
             },
             AggregateRating(ratingValue=2.12, bestRating=5.0, reviewCount=12),
@@ -332,7 +332,7 @@ def test_gtin(input_value, expected_value):
         (
             {
                 "ratingValue": "2.12",
-                "bestRating": "5,",
+                "bestRating": "5.0",
                 "reviewCount": "12,123",
             },
             AggregateRating(ratingValue=2.12, bestRating=5.0, reviewCount=12123),

--- a/zyte_common_items/processors.py
+++ b/zyte_common_items/processors.py
@@ -304,7 +304,7 @@ def rating_processor(value: Any, page: Any) -> Any:
     The input can also be a dictionary with one or more of the
     :class:`~zyte_common_items.AggregateRating` fields as keys. The values for
     those keys can be either final values, to be assigned to the corresponding
-    fields, or selector-like objects.
+    fields, strings to be parsed, or selector-like objects.
 
     If a returning dictionary is missing the ``bestRating`` field and
     ``ratingValue`` is a selector-like object, ``bestRating`` may be extracted.

--- a/zyte_common_items/processors.py
+++ b/zyte_common_items/processors.py
@@ -1,5 +1,5 @@
 from collections.abc import Iterable, Mapping
-from functools import partial, wraps
+from functools import wraps
 from numbers import Real
 from typing import Any, Callable, List, Optional, Union, Type
 
@@ -30,17 +30,23 @@ from .components import (
     Request,
 )
 
-def _to_number(value: Any, number_type: Type) -> Any:
+def _to_int(value) -> Any:
     if isinstance(value, Real):
-        return number_type(value)
+        return int(value)
+    elif isinstance(value, str):
+        if "," in value:
+            value = value.replace(",", "")
+        return int(value)
+    return value
+
+def _to_float(value) -> Any:
+    if isinstance(value, Real):
+        return float(value)
     elif isinstance(value, str):
         if "," in value:
             value = value.replace(",", ".")
-        return number_type(value)
+        return float(value)
     return value
-
-_to_int = partial(_to_number, number_type=int)
-_to_float = partial(_to_number, number_type=float)
 
 
 def _get_base_url(page: Any) -> Optional[str]:


### PR DESCRIPTION
Ratting processor currently accept dictionaries with standard keys `ratingValue`, `bestRating` and `reviewCount`. It attempts to convert values using `float` and `int` calls, so that string values are handled:
```python
>>> from zyte_common_items.processors import rating_processor
>>> 
>>> rating_processor({"bestRating": 5, "ratingValue": "3.3", "reviewCount": 12}, None)
AggregateRating(bestRating=5.0, ratingValue=3.3, reviewCount=12)
```
If the value of rating uses comma instead of a dot to separate decimal places, an exception is raised:
```python
>>> rating_processor({"bestRating": 5, "ratingValue": "3,3", "reviewCount": 12}, None)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/tmp/zyte_common_items/processors.py", line 354, in rating_processor
    result.ratingValue = float(rating_value)
                         ^^^^^^^^^^^^^^^^^^^
ValueError: could not convert string to float: '3,3'
```
Similarly, number of reviews can have comma in string value (seen in Amazon pages), e.g. `12,070 ratings`. Strings such as these also raise exceptions.

Because standard schema defines that `ratingValue` and `bestRating` use `Number` type and `revewCount` uses `Integer` type, decided to treat strings differently depending on used type:
* If we expect real value, try replacing `,` with `.`
* If we expect integer value, try removing `,`