### PR TITLE
Add BaseSearchRequestTemplatePage, change SearchRequestTemplatePage

### DIFF
--- a/docs/reference/pages.rst
+++ b/docs/reference/pages.rst
@@ -153,6 +153,9 @@ Social media post
 Request templates
 =================
 
+.. autoclass:: zyte_common_items.BaseSearchRequestTemplatePage(**kwargs)
+   :show-inheritance:
+
 .. autoclass:: zyte_common_items.SearchRequestTemplatePage(**kwargs)
    :show-inheritance:
 

--- a/docs/usage/request-templates.rst
+++ b/docs/usage/request-templates.rst
@@ -55,11 +55,11 @@ For example:
 .. code-block:: python
 
     from web_poet import handle_urls
-    from zyte_common_items import SearchRequestTemplatePage
+    from zyte_common_items import BaseSearchRequestTemplatePage
 
 
     @handle_urls("example.com")
-    class ExampleComSearchRequestTemplatePage(SearchRequestTemplatePage):
+    class ExampleComSearchRequestTemplatePage(BaseSearchRequestTemplatePage):
         @field
         def url(self):
             return "https://example.com/search?q={{ keyword|quote_plus }}"
@@ -87,7 +87,7 @@ very complex scenarios:
 
 .. code-block:: python
 
-    class ComplexSearchRequestTemplatePage(SearchRequestTemplatePage):
+    class ComplexSearchRequestTemplatePage(BaseSearchRequestTemplatePage):
         @field
         def url(self):
             return """

--- a/tests/test_pages.py
+++ b/tests/test_pages.py
@@ -158,11 +158,7 @@ def test_page_pairs():
         obj_name
         for obj_name in zyte_common_items.__dict__
         if (
-            not (
-                obj_name.startswith("Base")
-                or obj_name.startswith("Auto")
-                or obj_name.endswith("RequestTemplatePage")
-            )
+            not (obj_name.startswith("Base") or obj_name.startswith("Auto"))
             and obj_name.endswith("Page")
             and obj_name != "Page"
         )
@@ -185,7 +181,9 @@ def test_page_pairs():
         for obj_name in zyte_common_items.__dict__
         if (obj_name.startswith("Auto") and obj_name.endswith("Page"))
     }
-    expected_auto_pages = {f"Auto{page}" for page in pages}
+    expected_auto_pages = {
+        f"Auto{page}" for page in pages if not page.endswith("RequestTemplatePage")
+    }
     assert actual_auto_pages == expected_auto_pages
 
 
@@ -221,6 +219,11 @@ METADATA_FIELDS = {
     "RealEstate": {"dateDownloaded", "probability", "validationMessages"},
     "JobPosting": {"dateDownloaded", "probability", "searchText", "validationMessages"},
     "JobPostingNavigation": {"dateDownloaded", "validationMessages"},
+    "SearchRequestTemplate": {
+        "dateDownloaded",
+        "probability",
+        "validationMessages",
+    },
     "Serp": {
         "dateDownloaded",
         "displayedQuery",
@@ -292,11 +295,7 @@ def test_metadata():
         obj_name
         for obj_name in zyte_common_items.__dict__
         if (
-            not (
-                obj_name.startswith("Base")
-                or obj_name.startswith("Auto")
-                or obj_name.endswith("RequestTemplatePage")
-            )
+            not (obj_name.startswith("Base") or obj_name.startswith("Auto"))
             and obj_name.endswith("Page")
             and obj_name != "Page"
         )

--- a/zyte_common_items/__init__.py
+++ b/zyte_common_items/__init__.py
@@ -99,6 +99,7 @@ from .pages import (
     BaseProductNavigationPage,
     BaseProductPage,
     BaseRealEstatePage,
+    BaseSearchRequestTemplatePage,
     BaseSerpPage,
     BaseSocialMediaPostPage,
     BusinessPlacePage,

--- a/zyte_common_items/pages/__init__.py
+++ b/zyte_common_items/pages/__init__.py
@@ -27,7 +27,10 @@ from .product_navigation import (
     ProductNavigationPage,
 )
 from .real_estate import AutoRealEstatePage, BaseRealEstatePage, RealEstatePage
-from .search_request_template import SearchRequestTemplatePage
+from .search_request_template import (
+    BaseSearchRequestTemplatePage,
+    SearchRequestTemplatePage,
+)
 from .serp import AutoSerpPage, BaseSerpPage, SerpPage
 from .social_media_post import (
     AutoSocialMediaPostPage,

--- a/zyte_common_items/pages/search_request_template.py
+++ b/zyte_common_items/pages/search_request_template.py
@@ -9,7 +9,7 @@ from .mixins import HasMetadata
 class BaseSearchRequestTemplatePage(
     BasePage, Returns[SearchRequestTemplate], HasMetadata[SearchRequestTemplateMetadata]
 ):
-    """:class:`Page` subclass for :class:`SearchRequestTemplate`."""
+    """:class:`BasePage` subclass for :class:`SearchRequestTemplate`."""
 
 
 class SearchRequestTemplatePage(

--- a/zyte_common_items/pages/search_request_template.py
+++ b/zyte_common_items/pages/search_request_template.py
@@ -1,11 +1,18 @@
-from web_poet import ItemPage
+from web_poet import Returns
 
 from zyte_common_items.items import SearchRequestTemplate, SearchRequestTemplateMetadata
 
+from .base import BasePage, Page
 from .mixins import HasMetadata
 
 
-class SearchRequestTemplatePage(
-    ItemPage[SearchRequestTemplate], HasMetadata[SearchRequestTemplateMetadata]
+class BaseSearchRequestTemplatePage(
+    BasePage, Returns[SearchRequestTemplate], HasMetadata[SearchRequestTemplateMetadata]
 ):
-    pass
+    """:class:`Page` subclass for :class:`SearchRequestTemplate`."""
+
+
+class SearchRequestTemplatePage(
+    Page, Returns[SearchRequestTemplate], HasMetadata[SearchRequestTemplateMetadata]
+):
+    """:class:`Page` subclass for :class:`SearchRequestTemplate`."""


### PR DESCRIPTION
This is a backward-incompatible change that makes things more consistent with other, similar classes, and gives both classes access to the `no_item_found()` method from `_BasePage`.