### PR TITLE
[CIT-1532] Add displayedUrlText to 

### DIFF
--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -236,6 +236,7 @@ def test_serp_organic_result():
         name="Foobar",
         url="https://en.wikipedia.org/wiki/Foobar",
         rank=1,
+        displayedUrlText="https://en.wikipedia.org › wiki › F...",
     )
 
 

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -515,6 +515,7 @@ _SERP_ALL_KWARGS: dict = {
             name="Foobar",
             url="https://en.wikipedia.org/wiki/Foobar",
             rank=1,
+            displayedUrlText="https://en.wikipedia.org › wiki › F...",
         ),
     ],
     "url": "https://example.com/search?q=foo+bar",

--- a/zyte_common_items/items/serp.py
+++ b/zyte_common_items/items/serp.py
@@ -34,6 +34,9 @@ class SerpOrganicResult(Item):
     #: a search, must be 1.
     rank: Optional[int] = None
 
+    #: Result additional information such as number of instagram followers.
+    displayedUrlText: Optional[str] = None
+
 
 @attrs.define(kw_only=True)
 class SerpMetadata(ListMetadata):


### PR DESCRIPTION
A new `displayedUrlText` field to `SerpOrganicResult` was accepted as part of version 1.1 of Search Results schema.