### PR TITLE
Drop Python 3.9, bump tools.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.14'
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,10 +16,10 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          python-version: '3.14'
 
       - name: Build package
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,25 +17,22 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - python-version: '3.9'
         - python-version: '3.10'
         - python-version: '3.11'
         - python-version: '3.12'
         - python-version: '3.13'
-        - python-version: '3.14.0-rc.2'
-        - python-version: '3.9'
+        - python-version: '3.14'
+        - python-version: '3.10'
           toxenv: min
-        - python-version: '3.13'
+        - python-version: '3.14'
           toxenv: extra
-        - python-version: '3.14.0-rc.2'
-          toxenv: extra
-        - python-version: '3.9'
+        - python-version: '3.10'
           toxenv: min-extra
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -55,12 +52,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.12']  # Keep in sync with .readthedocs.yml
+        python-version: ['3.14']  # Keep in sync with .readthedocs.yml
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -75,6 +72,6 @@ jobs:
         tox -e twinecheck
         tox -e linters
     - name: coverage
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,6 @@ repos:
           - flake8-bugbear
           - flake8-comprehensions
           - flake8-debugger
-          - flake8-string-format
     repo: https://github.com/pycqa/flake8
     rev: 7.3.0
   - repo: https://github.com/adamchainz/blacken-docs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
     - id: end-of-file-fixer
     - id: trailing-whitespace
@@ -9,12 +9,12 @@ repos:
         exclude: test_mypy\.py$ # https://github.com/davidfritzsche/pytest-mypy-testing/issues/29
         language_version: python3
     repo: https://github.com/psf/black
-    rev: 24.10.0
+    rev: 26.1.0
   - hooks:
       - id: isort
         language_version: python3
     repo: https://github.com/timothycrosley/isort
-    rev: 5.13.2
+    rev: 7.0.0
   - hooks:
       - id: flake8
         language_version: python3
@@ -24,13 +24,13 @@ repos:
           - flake8-debugger
           - flake8-string-format
     repo: https://github.com/pycqa/flake8
-    rev: 7.1.1
+    rev: 7.3.0
   - repo: https://github.com/adamchainz/blacken-docs
-    rev: 1.19.0
+    rev: 1.20.0
     hooks:
       - id: blacken-docs
         additional_dependencies:
-          - black==24.10.0
+          - black==26.1.0
   - repo: local
     hooks:
       - id: no-colon-comments
@@ -39,3 +39,11 @@ repos:
         language: system
         types: [python]
         files: ^zyte_common_items/.*\.py$
+  - repo: https://github.com/sphinx-contrib/sphinx-lint
+    rev: v1.0.2
+    hooks:
+      - id: sphinx-lint
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.11
+    hooks:
+      - id: actionlint

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,11 +5,11 @@ sphinx:
   fail_on_warning: true
 
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   tools:
     # For available versions, see:
     # https://docs.readthedocs.io/en/stable/config-file/v2.html#build-tools-python
-    python: "3.12"  # Keep in sync with .github/workflows/test.yml
+    python: "3.14"  # Keep in sync with .github/workflows/test.yml
 
 python:
   install:

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ zyte-common-items
 
 .. description starts
 
-``zyte-common-items`` is a Python 3.9+ library of item_ and `page object`_
+``zyte-common-items`` is a Python 3.10+ library of item_ and `page object`_
 classes for web data extraction that we use at Zyte_ to maximize opportunities
 for code reuse.
 

--- a/docs/usage/request-templates.rst
+++ b/docs/usage/request-templates.rst
@@ -133,8 +133,7 @@ very complex scenarios:
         def headers(self):
             return [
                 Header(
-                    name=(
-                        """
+                    name=("""
                             {%-
                                 if query|length > 1
                                 and query[0]|lower == 'p'
@@ -143,8 +142,7 @@ very complex scenarios:
                             {%- else -%}
                                 Query
                             {%- endif -%}
-                        """
-                    ),
+                        """),
                     value="{{ query }}",
                 ),
             ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,17 +58,10 @@ multi_line_output = 3
 
 [tool.mypy]
 check_untyped_defs = true
+ignore_missing_imports = false
 implicit_reexport = false
 warn_no_return = false
 exclude = ['test_mypy\.py$', 'test_conversion\.py$']
-
-[[tool.mypy.overrides]]
-module = "clear_html"
-implicit_reexport = true  # to be fixed
-
-[[tool.mypy.overrides]]
-module = "zyte_parsers"
-implicit_reexport = true  # to be fixed
 
 [tool.pytest.ini_options]
 filterwarnings = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "zyte-common-items"
 dynamic = ["version"]
 description = "Item definitions for Zyte API schema"
 readme = { file = "README.rst", content-type = "text/x-rst" }
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [{ name = "Zyte Group Ltd", email = "info@zyte.com" }]
 classifiers = [
     "Development Status :: 3 - Alpha",
@@ -16,7 +16,6 @@ classifiers = [
     "Natural Language :: English",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -28,7 +27,7 @@ dependencies = [
     "attrs>=22.2.0",
     "clear-html>=0.4.0",
     "itemadapter>=0.8.0",
-    "Jinja2>=2.7",
+    "Jinja2>=2.10.2",
     "price-parser>=0.3.4",
     "web-poet>=0.14.0",
     "zyte-parsers>=0.5.0",

--- a/tests/test_mypy.py
+++ b/tests/test_mypy.py
@@ -18,7 +18,9 @@ NOTE:
 """
 
 import pytest
-from web_poet import HttpResponse
+
+# older web-poet doesn't explicitly export it, so "min" tests fail
+from web_poet import HttpResponse  # type: ignore[attr-defined]
 
 from zyte_common_items import (
     Breadcrumb,

--- a/tests/test_request_templates.py
+++ b/tests/test_request_templates.py
@@ -64,8 +64,7 @@ async def test_all():
         def headers(self):
             return [
                 Header(
-                    name=(
-                        """
+                    name=("""
                             {%-
                                 if query|length > 1
                                 and query[0]|lower == 'p'
@@ -74,8 +73,7 @@ async def test_all():
                             {%- else -%}
                                 Query
                             {%- endif -%}
-                        """
-                    ),
+                        """),
                     value="{{ query }}",
                 ),
             ]

--- a/tox.ini
+++ b/tox.ini
@@ -74,10 +74,12 @@ commands =
 [testenv:mypy]
 deps =
     mypy==1.19.1
+    clear-html==0.5.0
     price-parser==0.5.0
     pytest==8.4.2
     Scrapy==2.14.1
     types-lxml==2026.1.1
+    zyte-parsers==0.6.0
 
 commands = mypy zyte_common_items tests
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 min_version = 4.20
-envlist = min,min-extra,py39,py310,py311,py312,py313,py314,extra,mypy,docs,twinecheck
+envlist = min,min-extra,py310,py311,py312,py313,py314,extra,mypy,docs,twinecheck
 
 [base]
 deps =
@@ -8,9 +8,8 @@ deps =
     pytest
     pytest-asyncio
     pytest-cov
-    # the expected output uses Python 3.10 syntax
-    pytest-mypy-testing==0.1.3; python_version >= '3.10'
-    mypy==1.9.0; python_version >= '3.10'
+    pytest-mypy-testing==0.1.3
+    mypy==1.9.0
 
 [testenv]
 deps =
@@ -26,13 +25,14 @@ commands =
 
 
 [testenv:min]
-basepython = python3.9
+basepython = python3.10
 deps =
     {[base]deps}
     attrs==22.2.0
+    clear-html==0.4.0
     itemadapter==0.8.0
-    Jinja2==2.7
-    # For Jinja2:
+    Jinja2==2.10.2
+    # Pin markupsafe for Jinja2
     markupsafe==1.1.1
     price-parser==0.3.4
     web-poet==0.14.0
@@ -54,7 +54,7 @@ commands =
         {posargs:zyte_common_items docs tests}
 
 [testenv:min-extra]
-basepython = python3.9
+basepython = python3.10
 deps =
     {[testenv:min]deps}
     scrapy==2.0.1
@@ -73,18 +73,18 @@ commands =
 
 [testenv:mypy]
 deps =
-    mypy==1.18.2
+    mypy==1.19.1
     price-parser==0.5.0
     pytest==8.4.2
-    Scrapy==2.13.3
-    types-lxml==2025.8.25
+    Scrapy==2.14.1
+    types-lxml==2026.1.1
 
 commands = mypy zyte_common_items tests
 
 [testenv:twinecheck]
 deps =
-    twine==6.1.0
-    build==1.2.2.post1
+    twine==6.2.0
+    build==1.4.0
 commands =
     python -m build --sdist
     twine check dist/*


### PR DESCRIPTION
The minimum required `Jinja2` version is now 2.10.2.