### PR TITLE
Fix Union type check to handle Python 3.10+ native union syntax

### DIFF
--- a/zyte_common_items/base.py
+++ b/zyte_common_items/base.py
@@ -3,6 +3,12 @@
 from collections import ChainMap
 from typing import Dict, List, Optional, Union, get_args, get_origin, get_type_hints
 
+try:
+    from types import UnionType as _UnionType
+    _UNION_TYPES = (Union, _UnionType)
+except ImportError:  # Python < 3.10
+    _UNION_TYPES = (Union,)  # type: ignore[assignment]
+
 import attrs
 
 from .util import split_in_unknown_and_known_fields
@@ -131,7 +137,7 @@ class Item(ProbabilityMixin, _ItemBase):
         for field, type_annotation in annotations.items():
             origin = get_origin(type_annotation)
             is_optional = False
-            if origin == Union:
+            if origin in _UNION_TYPES:
                 field_classes = get_args(type_annotation)
                 if len(field_classes) != 2 or not isinstance(None, field_classes[1]):
                     path = f"{_get_import_path(cls)}.{field}"


### PR DESCRIPTION
When using Python 3.10+ union syntax like `X | Y` in type annotations, `get_origin()` returns `types.UnionType` instead of `typing.Union`. This means items using the new syntax would fail silently in `_apply_field_types_to_sub_fields` since the `if origin == Union:` check only handles the `typing.Union` case.

This is the same issue that was fixed in itemadapter's `_json_schema.py` (which already uses `UNION_TYPES = (Union, UnionType)` pattern).

Fix: add a try/except import for `types.UnionType` (Python 3.10+) and check against both union type forms.

Closes #147